### PR TITLE
Update time_val.rb

### DIFF
--- a/lib/stupidedi/versions/functional_groups/004010/element_types/time_val.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_types/time_val.rb
@@ -291,6 +291,7 @@ module Stupidedi
                 second = object.to_s.slice(4, 2).try{|ss| ss.to_d unless ss.blank? }
 
                 if decimal = object.to_s.slice(6..-1)
+                  decimal = 0 if decimal.empty?
                   second += "0.#{decimal}".to_d
                 end
 


### PR DESCRIPTION
If the object is 6 characters long, decimal is set to an empty string on line 293 (object.to_s.slice(6..-1) is an empty string). Since decimal is set, the if statement is true and the program steps into the block. In the block we now have "0.".to_d, which results in an ArgumentError (invalid value for BigDecimal(): "0.").

This change fixes this issue, as if decimal is an empty string, it will be changed to 0 before to_d is called on it.