### PR TITLE
Add utility to obfuscate data in X12 files

### DIFF
--- a/bin/edi-obfuscate
+++ b/bin/edi-obfuscate
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+#
+# This is a utility that will strip all free-form text (elements of type AN),
+# dates, and times from an X12 file. Strings are replaced with underscores,
+# dates are replaced with 2015-12-30, and times are replaced with 00:00:00.
+#
+# When -s is given, then unrecognized elements and segments will be suppressed
+# from the output.
+#
+# Otherwise, unrecognized segments or elements will cause an exception since it
+# is not possible to know if these should be obfuscated or not (they are invalid).
+#
+require File.expand_path("../../lib/stupidedi", __FILE__)
+
+require "stupidedi"
+require "pp"
+
+# Short-lived processes should win some peformance gains here
+GC.disable
+
+def main(argv)
+  strict = !argv.delete("-s")
+  config = Stupidedi::Config.default
+  reader = Stupidedi::Reader.build(File.open(argv[0]))
+
+  # First segment (ISA) specifies separators, used for parsing
+  result = reader.read_segment
+
+  result.tap do
+    lookup = result.remainder.segment_dict.push(
+      config.interchange.at(result.fetch.element_toks[11].value).segment_dict)
+
+    reader = result.remainder.copy(segment_dict: lookup)
+    delims = result.remainder.separators.copy(component: result.fetch.element_toks[15].value)
+    reader = reader.copy(separators: delims)
+
+    while result.defined?
+      result.tap do |token|
+        if token.id == :GS
+          gs08   = result.fetch.element_toks[7].value.slice(0, 6)
+          lookup = lookup.push(config.functional_group.at(gs08).segment_dict)
+          reader = reader.copy(segment_dict: lookup)
+        end
+
+        if lookup.defined_at?(token.id)
+          segment_def  = lookup.at(token.id)
+          element_toks = token.element_toks.zip(segment_def.element_uses).map.each_with_index do |(e, u), n|
+            if u.nil?
+              raise "unrecognized element: #{token.id}-#{"%02d" % n}" if strict
+
+              # This won't terminate the inner loop immediately, but if this
+              # element is unknown, it's because there were too many elements
+              # for the given segment. So all the extra elements at the end
+              # will still be skipped
+              next
+            elsif u.simple?
+              simple(e, u)
+            else
+              composite(e, u)
+            end
+          end.compact
+
+          puts token.copy(element_toks: element_toks).to_s(delims)
+        else
+          raise "unknown segment: #{token.id}" if strict
+          next
+        end
+      end
+
+      result = reader.read_segment
+      reader = result.remainder
+    end
+
+    result.explain{|msg| raise msg } if result.fatal?
+  end
+end
+
+def simple(e, u)
+  type = u.definition.class.name
+  type = (type || "?").split("::").last
+
+  # GS-08 and ST-03 are preserved, since these have special meaning to the parser
+  if e.blank? or [:E1705, :E480].include?(u.definition.id)
+    return e
+  end
+
+  if type.end_with?("AN")
+    e.copy(value: "_" * u.definition.min_length)
+  elsif type == "TM"
+    e.copy(value: "0" * e.value.length)
+  elsif type == "DT"
+    if e.value.length == 8
+      e.copy(value: "20151230")
+    else
+      e.copy(value: "151230")
+    end
+  else
+    e
+  end
+end
+
+def composite(e, u)
+  component_toks = []
+
+  e.component_toks.zip(u.definition.component_uses) do |ce, cu|
+    component_toks.push(simple(ce, cu))
+  end
+
+  e.copy(component_toks: component_toks)
+end
+
+main(ARGV)

--- a/lib/stupidedi/reader/tokens/component_element_tok.rb
+++ b/lib/stupidedi/reader/tokens/component_element_tok.rb
@@ -21,6 +21,14 @@ module Stupidedi
           value, position, remainder
       end
 
+      # @return [CompositeElementTok]
+      def copy(changes = {})
+        ComponentElementTok.new \
+          changes.fetch(:value, @value),
+          changes.fetch(:position, @position),
+          changes.fetch(:remainder, @remainder)
+      end
+
       def pretty_print(q)
         q.pp(:component.cons(@value.cons))
       end
@@ -39,6 +47,10 @@ module Stupidedi
 
       def composite?
         false
+      end
+
+      def to_s(separators)
+        @value
       end
     end
 

--- a/lib/stupidedi/reader/tokens/composite_element_tok.rb
+++ b/lib/stupidedi/reader/tokens/composite_element_tok.rb
@@ -21,6 +21,14 @@ module Stupidedi
           component_toks, position, remainder
       end
 
+      # @return [CompositeElementTok]
+      def copy(changes = {})
+        CompositeElementTok.new \
+          changes.fetch(:component_toks, @component_toks),
+          changes.fetch(:position, @position),
+          changes.fetch(:remainder, @remainder)
+      end
+
       def pretty_print(q)
         q.pp(:composite.cons(@component_toks))
       end
@@ -47,6 +55,15 @@ module Stupidedi
 
       def composite?
         true
+      end
+
+      def to_s(separators)
+        if blank?
+          ""
+        else
+          cs = @component_toks.map{|x| x.to_s(separators) }
+          cs.join(separators.component)
+        end
       end
     end
 

--- a/lib/stupidedi/reader/tokens/segment_tok.rb
+++ b/lib/stupidedi/reader/tokens/segment_tok.rb
@@ -24,16 +24,34 @@ module Stupidedi
           id, element_toks, position, remainder
       end
 
+      # @return [SegmentTok]
+      def copy(changes = {})
+        SegmentTok.new \
+          changes.fetch(:id, @id),
+          changes.fetch(:element_toks, @element_toks),
+          changes.fetch(:position, @position),
+          changes.fetch(:remainder, @remainder)
+      end
+
       def pretty_print(q)
         q.pp(:segment.cons(@id.cons(@element_toks)))
       end
 
       def blank?
-        @element_toks.all(&:blank?)
+        @element_toks.all?(&:blank?)
       end
 
       def present?
         not blank?
+      end
+
+      def to_s(separators)
+        if blank?
+          "#{id}#{separators.segment}"
+        else
+          es = @element_toks.map{|x| x.to_s(separators) }
+          id.cons(es).join(separators.element) + separators.segment
+        end
       end
     end
 

--- a/lib/stupidedi/reader/tokens/simple_element_tok.rb
+++ b/lib/stupidedi/reader/tokens/simple_element_tok.rb
@@ -21,6 +21,14 @@ module Stupidedi
           value, position, remainder
       end
 
+      # @return [SimpleElementTok]
+      def copy(changes = {})
+        SimpleElementTok.new \
+          changes.fetch(:value, @value),
+          changes.fetch(:position, @position),
+          changes.fetch(:remainder, @remainder)
+      end
+
       def pretty_print(q)
         q.pp(:simple.cons(@value.cons))
       end
@@ -47,6 +55,10 @@ module Stupidedi
 
       def composite?
         false
+      end
+
+      def to_s(separators)
+        @value
       end
     end
 


### PR DESCRIPTION
This might help users who want to share examples from their production system, but need to scrub any sensitive data. This replaces all string fields (AN), date fields (DT), and time fields (TM) with dummy data, but should keep enough intact that the obfuscated file can still be parsed.

```
$ ruby -Ilib notes/obfuscate.rb spec/fixtures/X224-HC837/1-good.txt
ISA*00*__________*01*__________*ZZ*_______________*ZZ*_______________*151230*0000*^*00501*000000905*1*T*:~
GS*HC*__*__*20151230*0000*1*X*005010X224A1~
ST*837*____*005010X224A1~
BHT*0019*00*_*20151230*0000*CH~
NM1*41*2*_*****46*__~
PER*IC*_*TE*_~
NM1*40*2*_*****46*__~
HL*_**20*1~
NM1*85*2*_*****XX*__~
N3*_~
N4*__*FL*331111234~
REF*EI*_~
HL*_*_*22*1~
SBR*P********CI~
NM1*IL*1*_*_****MI*__~
N3*_~
N4*__*FL*33111~
NM1*PR*2*_*****PI*__~
N4*__*FL*33111~
HL*_*_*23*0~
PAT*19~
NM1*QC*1*_*_~
N3*_~
N4*__*FL*33413~
...
```