### PR TITLE
Fix potential frozen string issues in pretty_print methods

### DIFF
--- a/lib/stupidedi/values/functional_group_val.rb
+++ b/lib/stupidedi/values/functional_group_val.rb
@@ -92,7 +92,7 @@ module Stupidedi
 
       # @return [String]
       def inspect
-        ansi.envelope("Group") << "(#{@children.map(&:inspect).join(', ')})"
+        ansi.envelope("Group") + "(#{@children.map(&:inspect).join(', ')})"
       end
 
       def ==(other)

--- a/lib/stupidedi/values/interchange_val.rb
+++ b/lib/stupidedi/values/interchange_val.rb
@@ -88,7 +88,7 @@ module Stupidedi
 
       # @return [String]
       def inspect
-        ansi.envelope("Interchange") << "(#{@children.map(&:inspect).join(', ')})"
+        ansi.envelope("Interchange") + "(#{@children.map(&:inspect).join(', ')})"
       end
 
       # @return [Boolean]

--- a/lib/stupidedi/values/loop_val.rb
+++ b/lib/stupidedi/values/loop_val.rb
@@ -59,7 +59,7 @@ module Stupidedi
 
       # @return [String]
       def inspect
-        ansi.loop("Loop") << "(#{@children.map(&:inspect).join(', ')})"
+        ansi.loop("Loop") + "(#{@children.map(&:inspect).join(', ')})"
       end
 
       # @return [Boolean]

--- a/lib/stupidedi/values/table_val.rb
+++ b/lib/stupidedi/values/table_val.rb
@@ -55,7 +55,7 @@ module Stupidedi
 
       # @return [String]
       def inspect
-        ansi.table("Table") << "(#{@children.map(&:inspect).join(', ')})"
+        ansi.table("Table") + "(#{@children.map(&:inspect).join(', ')})"
       end
 
       # @return [Boolean]

--- a/lib/stupidedi/values/transaction_set_val.rb
+++ b/lib/stupidedi/values/transaction_set_val.rb
@@ -55,7 +55,7 @@ module Stupidedi
 
       # @return [String]
       def inspect
-        ansi.envelope("Transaction") << "(#{@children.map(&:inspect).join(', ')})"
+        ansi.envelope("Transaction") + "(#{@children.map(&:inspect).join(', ')})"
       end
 
       # @return [Boolean]

--- a/lib/stupidedi/values/transmission_val.rb
+++ b/lib/stupidedi/values/transmission_val.rb
@@ -48,7 +48,7 @@ module Stupidedi
 
       # @return [String]
       def inspect
-        ansi.envelope("TransmissionVal") << "(#{@children.map(&:inspect).join(', ')})"
+        ansi.envelope("TransmissionVal") + "(#{@children.map(&:inspect).join(', ')})"
       end
     end
 

--- a/lib/stupidedi/versions/functional_groups/002001/element_types/date_val.rb
+++ b/lib/stupidedi/versions/functional_groups/002001/element_types/date_val.rb
@@ -90,7 +90,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("DT.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -282,7 +282,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(#{"%04d-%02d-%02d" % [year, month, day]})"
+                ansi.element("DT.value#{id}") + "(#{"%04d-%02d-%02d" % [year, month, day]})"
               end
 
               # @return [String]
@@ -463,7 +463,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
+                ansi.element("DT.value#{id}") + "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/002001/element_types/fixnum_val.rb
+++ b/lib/stupidedi/versions/functional_groups/002001/element_types/fixnum_val.rb
@@ -100,7 +100,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("Nn.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -239,7 +239,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.value#{id}") << "(#{to_s})"
+                ansi.element("Nn.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/002001/element_types/float_val.rb
+++ b/lib/stupidedi/versions/functional_groups/002001/element_types/float_val.rb
@@ -89,7 +89,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element(" R.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -229,7 +229,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.value#{id}") << "(#{to_s})"
+                ansi.element(" R.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/002001/element_types/identifier_val.rb
+++ b/lib/stupidedi/versions/functional_groups/002001/element_types/identifier_val.rb
@@ -119,7 +119,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("ID.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("ID.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/002001/element_types/string_val.rb
+++ b/lib/stupidedi/versions/functional_groups/002001/element_types/string_val.rb
@@ -79,7 +79,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("AN.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -263,7 +263,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.value#{id}") << "(#{@value})"
+                ansi.element("AN.value#{id}") + "(#{@value})"
               end
 
               def valid?

--- a/lib/stupidedi/versions/functional_groups/002001/element_types/time_val.rb
+++ b/lib/stupidedi/versions/functional_groups/002001/element_types/time_val.rb
@@ -76,7 +76,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("TM.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("TM.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -226,7 +226,7 @@ module Stupidedi
                 mm = @minute.try{|m| "%02d" % m }  || "mm"
                 ss = @second.try{|s| s.to_s("F") } || "ss"
 
-                ansi.element("TM.value#{id}") << "(#{hh}:#{mm}:#{ss})"
+                ansi.element("TM.value#{id}") + "(#{hh}:#{mm}:#{ss})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003010/element_types/date_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003010/element_types/date_val.rb
@@ -90,7 +90,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("DT.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -282,7 +282,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(#{"%04d-%02d-%02d" % [year, month, day]})"
+                ansi.element("DT.value#{id}") + "(#{"%04d-%02d-%02d" % [year, month, day]})"
               end
 
               # @return [String]
@@ -463,7 +463,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
+                ansi.element("DT.value#{id}") + "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003010/element_types/fixnum_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003010/element_types/fixnum_val.rb
@@ -100,7 +100,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("Nn.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -240,7 +240,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.value#{id}") << "(#{to_s})"
+                ansi.element("Nn.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003010/element_types/float_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003010/element_types/float_val.rb
@@ -89,7 +89,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element(" R.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -229,7 +229,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.value#{id}") << "(#{to_s})"
+                ansi.element(" R.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003010/element_types/identifier_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003010/element_types/identifier_val.rb
@@ -119,7 +119,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("ID.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("ID.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -318,7 +318,7 @@ module Stupidedi
                   value = @value
                 end
 
-                ansi.element("ID.value#{id}") << "(#{value})"
+                ansi.element("ID.value#{id}") + "(#{value})"
               end
             end
 

--- a/lib/stupidedi/versions/functional_groups/003010/element_types/string_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003010/element_types/string_val.rb
@@ -79,7 +79,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("AN.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -260,7 +260,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.value#{id}") << "(#{@value})"
+                ansi.element("AN.value#{id}") + "(#{@value})"
               end
 
               def valid?

--- a/lib/stupidedi/versions/functional_groups/003010/element_types/time_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003010/element_types/time_val.rb
@@ -76,7 +76,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("TM.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("TM.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -226,7 +226,7 @@ module Stupidedi
                 mm = @minute.try{|m| "%02d" % m }  || "mm"
                 ss = @second.try{|s| s.to_s("F") } || "ss"
 
-                ansi.element("TM.value#{id}") << "(#{hh}:#{mm}:#{ss})"
+                ansi.element("TM.value#{id}") + "(#{hh}:#{mm}:#{ss})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003040/element_types/date_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003040/element_types/date_val.rb
@@ -90,7 +90,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("DT.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -281,7 +281,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(#{"%04d-%02d-%02d" % [year, month, day]})"
+                ansi.element("DT.value#{id}") + "(#{"%04d-%02d-%02d" % [year, month, day]})"
               end
 
               # @return [String]
@@ -462,7 +462,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
+                ansi.element("DT.value#{id}") + "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003040/element_types/fixnum_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003040/element_types/fixnum_val.rb
@@ -100,7 +100,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("Nn.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -239,7 +239,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.value#{id}") << "(#{to_s})"
+                ansi.element("Nn.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003040/element_types/float_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003040/element_types/float_val.rb
@@ -89,7 +89,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element(" R.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -230,7 +230,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.value#{id}") << "(#{to_s})"
+                ansi.element(" R.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003040/element_types/identifier_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003040/element_types/identifier_val.rb
@@ -119,7 +119,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("ID.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("ID.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -316,7 +316,7 @@ module Stupidedi
                   value = @value
                 end
 
-                ansi.element("ID.value#{id}") << "(#{value})"
+                ansi.element("ID.value#{id}") + "(#{value})"
               end
             end
 

--- a/lib/stupidedi/versions/functional_groups/003040/element_types/string_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003040/element_types/string_val.rb
@@ -79,7 +79,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("AN.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -261,7 +261,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.value#{id}") << "(#{@value})"
+                ansi.element("AN.value#{id}") + "(#{@value})"
               end
 
               def valid?

--- a/lib/stupidedi/versions/functional_groups/003040/element_types/time_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003040/element_types/time_val.rb
@@ -76,7 +76,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("TM.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("TM.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -226,7 +226,7 @@ module Stupidedi
                 mm = @minute.try{|m| "%02d" % m }  || "mm"
                 ss = @second.try{|s| s.to_s("F") } || "ss"
 
-                ansi.element("TM.value#{id}") << "(#{hh}:#{mm}:#{ss})"
+                ansi.element("TM.value#{id}") + "(#{hh}:#{mm}:#{ss})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003050/element_types/date_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003050/element_types/date_val.rb
@@ -90,7 +90,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("DT.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -282,7 +282,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(#{"%04d-%02d-%02d" % [year, month, day]})"
+                ansi.element("DT.value#{id}") + "(#{"%04d-%02d-%02d" % [year, month, day]})"
               end
 
               # @return [String]
@@ -463,7 +463,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
+                ansi.element("DT.value#{id}") + "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003050/element_types/fixnum_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003050/element_types/fixnum_val.rb
@@ -100,7 +100,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("Nn.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -240,7 +240,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.value#{id}") << "(#{to_s})"
+                ansi.element("Nn.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003050/element_types/float_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003050/element_types/float_val.rb
@@ -89,7 +89,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element(" R.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -231,7 +231,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.value#{id}") << "(#{to_s})"
+                ansi.element(" R.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/003050/element_types/identifier_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003050/element_types/identifier_val.rb
@@ -119,7 +119,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("ID.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("ID.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -317,7 +317,7 @@ module Stupidedi
                   value = @value
                 end
 
-                ansi.element("ID.value#{id}") << "(#{value})"
+                ansi.element("ID.value#{id}") + "(#{value})"
               end
             end
 

--- a/lib/stupidedi/versions/functional_groups/003050/element_types/string_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003050/element_types/string_val.rb
@@ -79,7 +79,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("AN.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -262,7 +262,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.value#{id}") << "(#{@value})"
+                ansi.element("AN.value#{id}") + "(#{@value})"
               end
 
               def valid?

--- a/lib/stupidedi/versions/functional_groups/003050/element_types/time_val.rb
+++ b/lib/stupidedi/versions/functional_groups/003050/element_types/time_val.rb
@@ -76,7 +76,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("TM.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("TM.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -226,7 +226,7 @@ module Stupidedi
                 mm = @minute.try{|m| "%02d" % m }  || "mm"
                 ss = @second.try{|s| s.to_s("F") } || "ss"
 
-                ansi.element("TM.value#{id}") << "(#{hh}:#{mm}:#{ss})"
+                ansi.element("TM.value#{id}") + "(#{hh}:#{mm}:#{ss})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/004010/element_types/date_val.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_types/date_val.rb
@@ -90,7 +90,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("DT.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -283,7 +283,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(#{"%04d-%02d-%02d" % [year, month, day]})"
+                ansi.element("DT.value#{id}") + "(#{"%04d-%02d-%02d" % [year, month, day]})"
               end
 
               # @return [String]
@@ -464,7 +464,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.value#{id}") << "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
+                ansi.element("DT.value#{id}") + "(XX#{"%02d-%02d-%02d" % [@year, @month, @day]})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/004010/element_types/fixnum_val.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_types/fixnum_val.rb
@@ -100,7 +100,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("Nn.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -240,7 +240,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.value#{id}") << "(#{to_s})"
+                ansi.element("Nn.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/004010/element_types/float_val.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_types/float_val.rb
@@ -89,7 +89,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element(" R.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -230,7 +230,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.value#{id}") << "(#{to_s})"
+                ansi.element(" R.value#{id}") + "(#{to_s})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/004010/element_types/string_val.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_types/string_val.rb
@@ -79,7 +79,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("AN.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -262,7 +262,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.value#{id}") << "(#{@value})"
+                ansi.element("AN.value#{id}") + "(#{@value})"
               end
 
               def valid?

--- a/lib/stupidedi/versions/functional_groups/004010/element_types/time_val.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/element_types/time_val.rb
@@ -76,7 +76,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("TM.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("TM.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]
@@ -226,7 +226,7 @@ module Stupidedi
                 mm = @minute.try{|m| "%02d" % m }  || "mm"
                 ss = @second.try{|s| s.to_s("F") } || "ss"
 
-                ansi.element("TM.value#{id}") << "(#{hh}:#{mm}:#{ss})"
+                ansi.element("TM.value#{id}") + "(#{hh}:#{mm}:#{ss})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/005010/element_types/date_val.rb
+++ b/lib/stupidedi/versions/functional_groups/005010/element_types/date_val.rb
@@ -90,7 +90,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("DT.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("DT.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/005010/element_types/fixnum_val.rb
+++ b/lib/stupidedi/versions/functional_groups/005010/element_types/fixnum_val.rb
@@ -100,7 +100,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("Nn.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("Nn.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/005010/element_types/float_val.rb
+++ b/lib/stupidedi/versions/functional_groups/005010/element_types/float_val.rb
@@ -89,7 +89,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element(" R.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element(" R.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/005010/element_types/string_val.rb
+++ b/lib/stupidedi/versions/functional_groups/005010/element_types/string_val.rb
@@ -79,7 +79,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("AN.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("AN.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/functional_groups/005010/element_types/time_val.rb
+++ b/lib/stupidedi/versions/functional_groups/005010/element_types/time_val.rb
@@ -76,7 +76,7 @@ module Stupidedi
                   end
                 end
 
-                ansi.element("TM.invalid#{id}") << "(#{ansi.invalid(@value.inspect)})"
+                ansi.element("TM.invalid#{id}") + "(#{ansi.invalid(@value.inspect)})"
               end
 
               # @return [String]

--- a/lib/stupidedi/versions/interchanges/00200/element_defs.rb
+++ b/lib/stupidedi/versions/interchanges/00200/element_defs.rb
@@ -98,7 +98,7 @@ module Stupidedi
 
             def inspect
               id = definition.try{|d| ansi.bold("[#{d.id}]") }
-              ansi.element("SeparatorElementVal.value#{id}") << "(#{@value || "nil"})"
+              ansi.element("SeparatorElementVal.value#{id}") + "(#{@value || "nil"})"
             end
           end
 

--- a/lib/stupidedi/versions/interchanges/00300/element_defs.rb
+++ b/lib/stupidedi/versions/interchanges/00300/element_defs.rb
@@ -98,7 +98,7 @@ module Stupidedi
 
             def inspect
               id = definition.try{|d| ansi.bold("[#{d.id}]") }
-              ansi.element("SeparatorElementVal.value#{id}") << "(#{@value || "nil"})"
+              ansi.element("SeparatorElementVal.value#{id}") + "(#{@value || "nil"})"
             end
           end
 

--- a/lib/stupidedi/versions/interchanges/00400/element_defs.rb
+++ b/lib/stupidedi/versions/interchanges/00400/element_defs.rb
@@ -98,7 +98,7 @@ module Stupidedi
 
             def inspect
               id = definition.try{|d| ansi.bold("[#{d.id}]") }
-              ansi.element("SeparatorElementVal.value#{id}") << "(#{@value || "nil"})"
+              ansi.element("SeparatorElementVal.value#{id}") + "(#{@value || "nil"})"
             end
           end
 

--- a/lib/stupidedi/versions/interchanges/00401/element_defs.rb
+++ b/lib/stupidedi/versions/interchanges/00401/element_defs.rb
@@ -99,7 +99,7 @@ module Stupidedi
 
             def inspect
               id = definition.try{|d| ansi.bold("[#{d.id}]") }
-              ansi.element("SeparatorElementVal.value#{id}") << "(#{@value || "nil"})"
+              ansi.element("SeparatorElementVal.value#{id}") + "(#{@value || "nil"})"
             end
           end
 


### PR DESCRIPTION
I think I found a number of string mutations lurking in `inspect` methods. This was uncovered when piping the output from `edi-pp` into a text file -- when STDOUT is not a TTY, (some of) these methods get called rather than `pretty print`.