### PR TITLE
Fix minor issue for decimal values coercion less than 10 for TimeVal.

### DIFF
--- a/lib/stupidedi/versions/functional_groups/005010/element_types/time_val.rb
+++ b/lib/stupidedi/versions/functional_groups/005010/element_types/time_val.rb
@@ -292,7 +292,7 @@ module Stupidedi
                 decimal = object.to_s.slice(6..-1).try{|dd| dd.to_d unless dd.blank? }
 
                 if decimal
-                  second += "0.#{decimal}".to_d
+                  second += ("0.%02d" % decimal).to_d
                 end
 
                 self::NonEmpty.new(hour, minute, second, usage, position)


### PR DESCRIPTION
Whoops 😟, there was a minor issue for values less than 10. Should be fine now:

```
BHT*0022*11*22*20150520*06280209~ => TM.value[ E337: Transaction Set Creation Time](06:28:2.09)

BHT*0022*11*22*20150520*06281242~ => TM.value[ E337: Transaction Set Creation Time](06:28:2.42),
```