### PR TITLE
Re-enable EC Segment on FifyTen group

### DIFF
--- a/lib/stupidedi/versions/functional_groups/005010/segment_defs.rb
+++ b/lib/stupidedi/versions/functional_groups/005010/segment_defs.rb
@@ -10,8 +10,8 @@ module Stupidedi
           autoload :AAA,
             "stupidedi/versions/functional_groups/005010/segment_defs/AAA"
 
-         autoload :ACT,
-           "stupidedi/versions/functional_groups/005010/segment_defs/ACT"
+          autoload :ACT,
+            "stupidedi/versions/functional_groups/005010/segment_defs/ACT"
 
           autoload :AK1,
             "stupidedi/versions/functional_groups/005010/segment_defs/AK1"
@@ -91,8 +91,11 @@ module Stupidedi
           autoload :DTP,
             "stupidedi/versions/functional_groups/005010/segment_defs/DTP"
 
- 	  autoload :EB,
+          autoload :EB,
             "stupidedi/versions/functional_groups/005010/segment_defs/EB"
+
+          autoload :EC,
+            "stupidedi/versions/functional_groups/005010/segment_defs/EC"
 
           autoload :EQ,
             "stupidedi/versions/functional_groups/005010/segment_defs/EQ"
@@ -114,9 +117,9 @@ module Stupidedi
 
           autoload :HLH,
             "stupidedi/versions/functional_groups/005010/segment_defs/HLH"
-	    
-	  autoload :III,
-            "stupidedi/versions/functional_groups/005010/segment_defs/III"  
+
+          autoload :III,
+            "stupidedi/versions/functional_groups/005010/segment_defs/III"
 
           autoload :ICM,
             "stupidedi/versions/functional_groups/005010/segment_defs/ICM"


### PR DESCRIPTION
This was removed [here](https://github.com/irobayna/stupidedi/commit/57c5b68e8b40e47ac9468f1e0bc30b7fad98eea2#diff-a7e1941f7ff6de3e7c2eb7b0b54eb07dL94) and was originally added [here](https://github.com/irobayna/stupidedi/commit/c28a63d7ad003b24eaf00306e1cf2aa931a7f60e#diff-a7e1941f7ff6de3e7c2eb7b0b54eb07dR94)

I don't see a reason not to have this enabled in AutoLoad. Trying to add it back if possible.