### PR TITLE
* call find! on StateMachine not Either wrapper

### DIFF
--- a/lib/stupidedi/editor/004010.rb
+++ b/lib/stupidedi/editor/004010.rb
@@ -156,7 +156,7 @@ module Stupidedi
                 end
               end
 
-            st.find!(:ST)
+            st_.find!(:ST)
           end
         end
 


### PR DESCRIPTION
* Previously, this find! method was being called on a StateMachine
instance wrapped with Either, instead of the StateMachine itself,
resulting in an error

* Instead of st.find!, we use st_.find! (which is what is used in the
005010.rb file as well), resolving the error