### PR TITLE
Update 4010 element definition for TF

### DIFF
--- a/lib/stupidedi/versions/004010/element_defs.rb
+++ b/lib/stupidedi/versions/004010/element_defs.rb
@@ -30,7 +30,7 @@ module Stupidedi
             "RC" => "Refrigerated (Reefer) Car",
             "RT" => "Controlled Temperature Trailer (Reefer)",
             "SU" => "Supplier/Manufacturer",
-            "TF" => "Trailer, Try Freight",
+            "TF" => "Trailer, Dry Freight",
             "TL" => "Trailer (not otherwise specified)",
             "TV" => "Truck, Van"))
         E46   = t::AN.new(:E46  , "Ex Parte"                             , 4, 4)


### PR DESCRIPTION
This update fixes a spelling error. The correct definition for 'TF' is 'Trailer, Dry Freight', not 'Trailer, Try Freight'.

It is odd that 'Trailer, Dry Freight' is abbreviated to 'TF' but that's not the only weird thing about this spec!